### PR TITLE
Fix Coke countdown

### DIFF
--- a/ExtraInfo/modinfo.json
+++ b/ExtraInfo/modinfo.json
@@ -6,7 +6,7 @@
     "description": "Useful information for handbook, blocks, items and entities",
     "authors": ["Craluminum2413"],
     "contributors": ["Novocain"],
-    "version": "1.11.0",
+    "version": "1.11.1",
     "dependencies": {
         "game": "1.21.0"
     }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -341,17 +341,18 @@ public static class InfoExtensions
                 return __result;
             }
 
-            double? hours = neighborBE?.GetHoursLeft(neighborBE.GetField<double>("burnStartTotalHours"));
-
-            if (!hours.HasValue)
+            if (neighborBE == null)
             {
                 continue;
             }
 
+            double burnStart = neighborBE.GetField<double>("burnStartTotalHours");
+            double hours = 12.0 - (world.Calendar.TotalHours - burnStart);
+
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours.Value)));
+                .Append(ColorText(Text.Hours(hours)));
 
             return sb.ToString().TrimEnd();
         }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -352,7 +352,7 @@ public static class InfoExtensions
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours)));
+                .Append(ColorText(Text.HoursAndMinutes(hours)));
 
             return sb.ToString().TrimEnd();
         }


### PR DESCRIPTION
I found that Coke was always displaying "0 hours".  This ensures that it counts down properly, and uses `HoursAndMinutes` over `Hours` so you don't accidentally open the door when there's less than an hour left.