### PR TITLE
Improve steel making info

### DIFF
--- a/ExtraInfo/assets/extrainfo/lang/en.json
+++ b/ExtraInfo/assets/extrainfo/lang/en.json
@@ -63,5 +63,7 @@
     "Mechanics.Speed": "Speed: {0:G4}",
     "Mechanics.TotalAvailableTorque": "Available Torque: {0:G4}",
     "Mechanics.NetworkTorque": "Total Torque: {0:G4}",
-    "Mechanics.NetworkResistance": "Resistance: {0:G4}"
+    "Mechanics.NetworkResistance": "Resistance: {0:G4}",
+
+    "Carburization.Starting": "Carburization: Starting..."
 }

--- a/ExtraInfo/modinfo.json
+++ b/ExtraInfo/modinfo.json
@@ -6,7 +6,7 @@
     "description": "Useful information for handbook, blocks, items and entities",
     "authors": ["Craluminum2413"],
     "contributors": ["Novocain"],
-    "version": "1.11.0",
+    "version": "1.11.1",
     "dependencies": {
         "game": "1.21.0"
     }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -341,17 +341,18 @@ public static class InfoExtensions
                 return __result;
             }
 
-            double? hours = neighborBE?.GetHoursLeft(neighborBE.GetField<double>("burnStartTotalHours"));
-
-            if (!hours.HasValue)
+            if (neighborBE == null)
             {
                 continue;
             }
 
+            double burnStart = neighborBE.GetField<double>("burnStartTotalHours");
+            double hours = 12.0 - (world.Calendar.TotalHours - burnStart);
+
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours.Value)));
+                .Append(ColorText(Text.Hours(hours)));
 
             return sb.ToString().TrimEnd();
         }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -352,7 +352,7 @@ public static class InfoExtensions
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours)));
+                .Append(ColorText(Text.HoursAndMinutes(hours)));
 
             return sb.ToString().TrimEnd();
         }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -367,41 +367,76 @@ public static class InfoExtensions
             return __result;
         }
 
-        if (world.BlockAccessor.GetBlock(pos) is not BlockDoor blockDoor) return __result;
-        if (blockDoor.FirstCodePart() != "irondoor") return __result;
+        Block block = world.BlockAccessor.GetBlock(pos);
+        string codePath = block.Code.Path;
+
+        // Check if this is an iron door (regular or metal variant)
+        bool isIronDoor = codePath.Contains("irondoor") ||
+                          (codePath.Contains("door") && codePath.Contains("iron"));
+        if (!isIronDoor) return __result;
 
         StringBuilder sb = new(__result);
 
-        BlockPos _pos = blockDoor.IsUpperHalf() switch
-        {
-            true => pos.DownCopy(),
-            false => pos,
-        };
-
+        // From door, coffin is 2 blocks away in a cardinal direction at same Y level
         BlockPos[] neighborPositions = new BlockPos[]
         {
-            _pos.NorthCopy(3),
-            _pos.EastCopy(3),
-            _pos.SouthCopy(3),
-            _pos.WestCopy(3)
+            pos.NorthCopy(2),
+            pos.EastCopy(2),
+            pos.SouthCopy(2),
+            pos.WestCopy(2)
         };
 
-        foreach (BlockPos blockPos in neighborPositions)
+        foreach (BlockPos coffinPos in neighborPositions)
         {
-            if (world.BlockAccessor.GetBlockEntity(blockPos) is not BlockEntityStoneCoffin be) continue;
+            var coffinBlock = world.BlockAccessor.GetBlock(coffinPos);
 
-            bool processComplete = be.GetField<bool>("processComplete");
-            if (processComplete)
+            // Look for stonecoffin or stonecoffinsection
+            if (!coffinBlock.Code.Path.Contains("stonecoffin")) continue;
+
+            // Get the coffin entity (stonecoffinsection has BlockEntityStoneCoffin)
+            if (world.BlockAccessor.GetBlockEntity(coffinPos) is BlockEntityStoneCoffin be)
             {
-                sb.AppendLine(Lang.Get("Carburization process complete. Break to retrieve blister steel."));
-                continue;
+                bool processComplete = be.GetField<bool>("processComplete");
+                if (processComplete)
+                {
+                    sb.AppendLine(Lang.Get("Carburization process complete. Break to retrieve blister steel."));
+                }
+                else
+                {
+                    double progress = be.GetField<double>("progress");
+                    if (progress > 0.0)
+                    {
+                        int percent = (int)(progress * 100.0);
+                        sb.AppendLine(Text.CarburizationComplete(percent));
+                    }
+                }
             }
 
-            double progress = be.GetField<double>("progress");
-            if (progress <= 0.0) continue;
+            // Fuel is 2 blocks below the coffin
+            BlockPos fuelPos = coffinPos.DownCopy(2);
+            if (world.BlockAccessor.GetBlockEntity(fuelPos) is BlockEntityCoalPile fuelPile)
+            {
+                if (fuelPile.IsBurning)
+                {
+                    // Calculate actual burn time based on fuel type and stack size
+                    float burnHoursPerLayer = fuelPile.BurnHoursPerLayer;
+                    var inventory = fuelPile.GetField<InventoryGeneric>("inventory");
+                    int stackSize = inventory?[0]?.StackSize ?? 0;
+                    double totalBurnHours = stackSize / 2.0 * burnHoursPerLayer;
 
-            int percent = (int)(progress * 100.0);
-            sb.AppendLine(Text.CarburizationComplete(percent));
+                    double burnStart = fuelPile.GetField<double>("burnStartTotalHours");
+                    double hoursElapsed = world.Calendar.TotalHours - burnStart;
+                    double hours = totalBurnHours - hoursElapsed;
+
+                    sb.AppendLine(ColorText(Text.Fuel + ": " + Text.HoursAndMinutes(hours)));
+                }
+                else
+                {
+                    sb.AppendLine(ColorText(Text.Fuel + ": " + Lang.Get("Not burning")));
+                }
+            }
+
+            break; // Found the coffin, no need to check other directions
         }
 
         return sb.ToString().TrimEnd();

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -393,6 +393,11 @@ public static class InfoExtensions
             // Look for stonecoffin or stonecoffinsection
             if (!coffinBlock.Code.Path.Contains("stonecoffin")) continue;
 
+            // Check fuel status first (2 blocks below the coffin)
+            BlockPos fuelPos = coffinPos.DownCopy(2);
+            var fuelPile = world.BlockAccessor.GetBlockEntity(fuelPos) as BlockEntityCoalPile;
+            bool isBurning = fuelPile?.IsBurning ?? false;
+
             // Get the coffin entity (stonecoffinsection has BlockEntityStoneCoffin)
             if (world.BlockAccessor.GetBlockEntity(coffinPos) is BlockEntityStoneCoffin be)
             {
@@ -409,14 +414,17 @@ public static class InfoExtensions
                         int percent = (int)(progress * 100.0);
                         sb.AppendLine(Text.CarburizationComplete(percent));
                     }
+                    else if (isBurning)
+                    {
+                        sb.AppendLine(Lang.Get("extrainfo:Carburization.Starting"));
+                    }
                 }
             }
 
-            // Fuel is 2 blocks below the coffin
-            BlockPos fuelPos = coffinPos.DownCopy(2);
-            if (world.BlockAccessor.GetBlockEntity(fuelPos) is BlockEntityCoalPile fuelPile)
+            // Display fuel status
+            if (fuelPile != null)
             {
-                if (fuelPile.IsBurning)
+                if (isBurning)
                 {
                     // Calculate actual burn time based on fuel type and stack size
                     float burnHoursPerLayer = fuelPile.BurnHoursPerLayer;


### PR DESCRIPTION
Improves the steel-making (carburization) information display when looking at iron doors near stone coffins.  Not that this builds off of #5.

###  Changes:
  - Improved iron door detection to recognize both standard irondoor and metal door variants
  - Fixed coffin detection distance (changed from 3 to 2 blocks to match actual placement)
  - Added support for detecting stonecoffinsection blocks
  - Added fuel status display showing whether the coal pile is burning and remaining burn time in hours/minutes
  - Optimized search by stopping once a coffin is found

###  Test plan

  - Place a stone coffin steel-making setup with an iron door
  - Verify carburization progress percentage displays correctly
  - Verify "process complete" message shows when steel is ready
  - Verify fuel burning status and remaining time display correctly
  - Test with both standard iron doors and metal variant doors
