### PR TITLE
Improve beehive kiln info

### DIFF
--- a/ExtraInfo/assets/extrainfo/lang/en.json
+++ b/ExtraInfo/assets/extrainfo/lang/en.json
@@ -67,4 +67,6 @@
     "Mechanics.NetworkResistance": "Resistance: {0:G4}",
 
     "Carburization.Starting": "Carburization: Starting..."
+    "Unfired": "Unfired",
+    "Fired": "Fired"
 }

--- a/ExtraInfo/assets/extrainfo/lang/en.json
+++ b/ExtraInfo/assets/extrainfo/lang/en.json
@@ -16,6 +16,7 @@
 
     "Config.Category.Crafting": "Crafting",
     "Config.Setting.ShowAnvilWorkableTemp": "Show the workable temperature on the anvil",
+    "Config.Setting.ShowBeehiveKilnProgress": "Show remaining time for the beehive kiln on the door",
     "Config.Setting.ShowBloomeryProgress": "Show progress of the bloomery",
     "Config.Setting.ShowCementationFurnaceProgress": "Show progress for steel production in the cementation furnace",
     "Config.Setting.ShowCharcoalPitProgress": "Show progress of charcoal production in the charcoal pit",

--- a/ExtraInfo/assets/extrainfo/lang/en.json
+++ b/ExtraInfo/assets/extrainfo/lang/en.json
@@ -63,5 +63,7 @@
     "Mechanics.Speed": "Speed: {0:G4}",
     "Mechanics.TotalAvailableTorque": "Available Torque: {0:G4}",
     "Mechanics.NetworkTorque": "Total Torque: {0:G4}",
-    "Mechanics.NetworkResistance": "Resistance: {0:G4}"
+    "Mechanics.NetworkResistance": "Resistance: {0:G4}",
+
+    "Carburization.Starting": "Carburization: Starting..."
 }

--- a/ExtraInfo/modinfo.json
+++ b/ExtraInfo/modinfo.json
@@ -6,7 +6,7 @@
     "description": "Useful information for handbook, blocks, items and entities",
     "authors": ["Craluminum2413"],
     "contributors": ["Novocain"],
-    "version": "1.11.0",
+    "version": "1.11.1",
     "dependencies": {
         "game": "1.21.0"
     }

--- a/ExtraInfo/src/Configuration/Config.cs
+++ b/ExtraInfo/src/Configuration/Config.cs
@@ -16,6 +16,7 @@ public class Config
     public bool ShowHandbookWorkableTemp { get; set; } = true;
 
     public bool ShowAnvilWorkableTemp { get; set; } = true;
+    public bool ShowBeehiveKilnProgress { get; set; } = true;
     public bool ShowBloomeryProgress { get; set; } = true;
     public bool ShowCementationFurnaceProgress { get; set; } = true;
     public bool ShowCharcoalPitProgress { get; set; } = true;
@@ -53,6 +54,7 @@ public class Config
         ShowHandbookWorkableTemp = previousConfig.ShowHandbookWorkableTemp;
 
         ShowAnvilWorkableTemp = previousConfig.ShowAnvilWorkableTemp;
+        ShowBeehiveKilnProgress = previousConfig.ShowBeehiveKilnProgress;
         ShowBloomeryProgress = previousConfig.ShowBloomeryProgress;
         ShowCementationFurnaceProgress = previousConfig.ShowCementationFurnaceProgress;
         ShowCharcoalPitProgress = previousConfig.ShowCharcoalPitProgress;

--- a/ExtraInfo/src/HarmonyPatches/PlacedBlockInfoPatch.cs
+++ b/ExtraInfo/src/HarmonyPatches/PlacedBlockInfoPatch.cs
@@ -11,5 +11,6 @@ public static class PlacedBlockInfoPatch
         __result = __result.GetSteelInfo(world, pos);
         __result = __result.GetCharcoalPitInfo(world, pos);
         __result = __result.GetBlockBreakingTimeInfo(world, pos);
+        __result = __result.GetBeehiveKilnInfo(world, pos);
     }
 }

--- a/ExtraInfo/src/Systems/ConfigLibCompatibility.cs
+++ b/ExtraInfo/src/Systems/ConfigLibCompatibility.cs
@@ -42,6 +42,7 @@ public class ConfigLibCompatibility
         ImGui.NewLine();
         ImGui.TextWrapped(Lang.Get(categoryCrafting));
         config.ShowAnvilWorkableTemp = OnCheckBox(id, config.ShowAnvilWorkableTemp, nameof(config.ShowAnvilWorkableTemp));
+        config.ShowBeehiveKilnProgress = OnCheckBox(id, config.ShowBeehiveKilnProgress, nameof(config.ShowBeehiveKilnProgress));
         config.ShowBloomeryProgress = OnCheckBox(id, config.ShowBloomeryProgress, nameof(config.ShowBloomeryProgress));
         config.ShowCementationFurnaceProgress = OnCheckBox(id, config.ShowCementationFurnaceProgress, nameof(config.ShowCementationFurnaceProgress));
         config.ShowCharcoalPitProgress = OnCheckBox(id, config.ShowCharcoalPitProgress, nameof(config.ShowCharcoalPitProgress));

--- a/ExtraInfo/src/Utility/Constants.cs
+++ b/ExtraInfo/src/Utility/Constants.cs
@@ -61,6 +61,11 @@ public static class Constants
         public static readonly string WarmingUp = Lang.Get("Warming up...");
         public static readonly string YouCanBuy = Lang.Get("You can Buy");
         public static readonly string YouCanSell = Lang.Get("You can Sell");
+        public static readonly string Kiln = Lang.Get("Kiln");
+        public static readonly string KilnFiringComplete = Lang.Get("Kiln firing complete");
+        public static readonly string NotBurning = Lang.Get("Not burning");
+        public static readonly string Unfired = Lang.Get("extrainfo:Unfired");
+        public static readonly string Fired = Lang.Get("extrainfo:Fired");
 
         public static string Damage(float damage) => Lang.Get("extrainfo:Damage", damage);
         public static string DamageTier(int damageTier) => Lang.Get("Damage tier: {0}", damageTier);

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -341,17 +341,18 @@ public static class InfoExtensions
                 return __result;
             }
 
-            double? hours = neighborBE?.GetHoursLeft(neighborBE.GetField<double>("burnStartTotalHours"));
-
-            if (!hours.HasValue)
+            if (neighborBE == null)
             {
                 continue;
             }
 
+            double burnStart = neighborBE.GetField<double>("burnStartTotalHours");
+            double hours = 12.0 - (world.Calendar.TotalHours - burnStart);
+
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours.Value)));
+                .Append(ColorText(Text.Hours(hours)));
 
             return sb.ToString().TrimEnd();
         }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -4,6 +4,13 @@ namespace ExtraInfo;
 
 public static class InfoExtensions
 {
+    // Debug logging helper - kept for future debugging needs.
+    // Usage: DebugLog(world, "message");
+    private static void DebugLog(IWorldAccessor world, string message)
+    {
+        world?.Logger?.Notification("[ExtraInfo] " + message);
+    }
+
     public static void GetWorkableTempInfoForAnvil(this StringBuilder dsc, BlockEntityAnvil blockEntity)
     {
         if (Core.Config == null || !Core.Config.ShowAnvilWorkableTemp)
@@ -387,23 +394,146 @@ public static class InfoExtensions
                     var be = world.BlockAccessor.GetBlockEntity(neighborPos);
                     if (be?.GetType().Name != "BlockEntityBeeHiveKiln") continue;
 
-                    bool receivesHeat = be.GetField<bool>("receivesHeat");
-                    if (!receivesHeat) continue;
+                    // Calculate direction from door to kiln interior (only use X/Z, ignore Y)
+                    int dirX = Math.Sign(neighborPos.X - pos.X);
+                    int dirZ = Math.Sign(neighborPos.Z - pos.Z);
 
-                    double totalHoursHeatReceived = be.GetField<double>("TotalHoursHeatReceived");
-                    double hoursRemaining = BeehiveKilnFiringHours - totalHoursHeatReceived;
-
-                    if (hoursRemaining > 0)
+                    // If kiln entity is at same position as door, detect direction by looking for ground storage
+                    if (dirX == 0 && dirZ == 0)
                     {
-                        sb.AppendLine();
-                        sb.Append(ColorText(Lang.Get("Kiln")));
-                        sb.Append(": ");
-                        sb.Append(ColorText(Text.HoursAndMinutes(hoursRemaining)));
+                        // Check each cardinal direction for ground storage
+                        BlockPos[] cardinals = new[] { pos.NorthCopy(), pos.EastCopy(), pos.SouthCopy(), pos.WestCopy() };
+                        foreach (var checkPos in cardinals)
+                        {
+                            if (world.IsGroundStorage(checkPos, out _))
+                            {
+                                dirX = Math.Sign(checkPos.X - pos.X);
+                                dirZ = Math.Sign(checkPos.Z - pos.Z);
+                                break;
+                            }
+                        }
+
+                        // If no ground storage, try to find grating blocks (at Y-1)
+                        if (dirX == 0 && dirZ == 0)
+                        {
+                            foreach (var checkPos in cardinals)
+                            {
+                                var grateCheckPos = checkPos.DownCopy(1);
+                                var grateBlock = world.BlockAccessor.GetBlock(grateCheckPos);
+                                if (grateBlock?.Code?.Path?.Contains("grating") == true)
+                                {
+                                    dirX = Math.Sign(checkPos.X - pos.X);
+                                    dirZ = Math.Sign(checkPos.Z - pos.Z);
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Still couldn't determine direction
+                        if (dirX == 0 && dirZ == 0) continue;
+                    }
+
+                    // Perpendicular direction for the 3-wide grid
+                    int perpX = dirZ;
+                    int perpZ = -dirX;
+
+                    // Build 3x3 grid positions (depth 1-3, width -1 to +1)
+                    List<BlockPos> gridPositions = new();
+                    for (int depth = 1; depth <= 3; depth++)
+                    {
+                        for (int side = -1; side <= 1; side++)
+                        {
+                            int gx = dirX * depth + perpX * side;
+                            int gz = dirZ * depth + perpZ * side;
+                            gridPositions.Add(pos.AddCopy(gx, 0, gz));
+                        }
+                    }
+
+                    // Analyze kiln contents - includes max heat received by any unfired item
+                    var (unfired, fired, maxHoursHeatReceived) = AnalyzeKilnContents(world, gridPositions);
+
+                    // Get fuel time remaining
+                    double fuelTimeRemaining = GetMinFuelTimeRemaining(world, gridPositions);
+
+                    // Get kiln status and calculate time remaining based on item heat, not kiln total
+                    bool receivesHeat = be.GetField<bool>("receivesHeat");
+                    double hoursRemaining = BeehiveKilnFiringHours - maxHoursHeatReceived;
+
+                    // Display kiln timer
+                    sb.AppendLine();
+                    if (receivesHeat && unfired > 0)
+                    {
+                        // Kiln is actively firing with unfired items
+                        if (hoursRemaining > 0)
+                        {
+                            sb.Append(ColorText(Text.Kiln));
+                            sb.Append(": ");
+                            sb.Append(ColorText(Text.HoursAndMinutes(hoursRemaining)));
+                        }
+                        else
+                        {
+                            // Timer exceeded but still receiving heat - items should be done soon
+                            sb.Append(ColorText(Text.Kiln));
+                            sb.Append(": ");
+                            sb.Append(ColorText(Lang.Get("Firing")));
+                        }
+                    }
+                    else if (receivesHeat && unfired == 0 && fired > 0)
+                    {
+                        sb.Append(ColorText(Text.KilnFiringComplete));
+                    }
+                    else if (receivesHeat && unfired == 0 && fired == 0)
+                    {
+                        sb.Append(ColorText(Lang.Get("Nothing in kiln to fire")));
+                    }
+                    else if (!receivesHeat && unfired > 0)
+                    {
+                        sb.Append(ColorText(Lang.Get("Items still unfired - add fuel")));
+                    }
+                    else if (!receivesHeat && unfired == 0 && fired > 0)
+                    {
+                        sb.Append(ColorText(Text.KilnFiringComplete));
                     }
                     else
                     {
+                        sb.Append(ColorText(Text.Kiln));
+                        sb.Append(": ");
+                        sb.Append(ColorText(Text.NotBurning));
+                    }
+
+                    // Display item counts if any items present
+                    if (unfired > 0 || fired > 0)
+                    {
                         sb.AppendLine();
-                        sb.Append(ColorText(Lang.Get("Kiln firing complete")));
+                        if (unfired > 0)
+                        {
+                            sb.Append(ColorText(Text.Unfired));
+                            sb.Append(": ");
+                            sb.Append(unfired);
+                        }
+                        if (unfired > 0 && fired > 0)
+                        {
+                            sb.Append(" | ");
+                        }
+                        if (fired > 0)
+                        {
+                            sb.Append(ColorText(Text.Fired));
+                            sb.Append(": ");
+                            sb.Append(fired);
+                        }
+                    }
+
+                    // Display fuel status
+                    sb.AppendLine();
+                    sb.Append(ColorText(Text.Fuel));
+                    sb.Append(": ");
+                    if (fuelTimeRemaining >= 0)
+                    {
+                        sb.Append(ColorText(Text.HoursAndMinutes(fuelTimeRemaining)));
+                    }
+                    else
+                    {
+                        sb.Append(ColorText(Text.NotBurning));
                     }
 
                     return sb.ToString().TrimEnd();
@@ -412,6 +542,83 @@ public static class InfoExtensions
         }
 
         return __result;
+    }
+
+    private static bool IsUnfiredItem(ItemStack stack)
+    {
+        if (stack == null) return false;
+        string code = stack.Collectible.Code.Path.ToLowerInvariant();
+        return code.Contains("-raw") || code.Contains("rawclay") ||
+               code.Contains("clayform") || code.Contains("unfired");
+    }
+
+    private static (int unfired, int fired, double maxHoursHeatReceived) AnalyzeKilnContents(IWorldAccessor world, List<BlockPos> positions)
+    {
+        int unfired = 0;
+        int fired = 0;
+        double maxHoursHeatReceived = 0;
+
+        foreach (var gridPos in positions)
+        {
+            if (world.IsGroundStorage(gridPos, out var gs))
+            {
+                var stack = gs.GetContainedStack();
+                if (stack != null)
+                {
+                    int amount = gs.GetTotalAmount();
+                    if (IsUnfiredItem(stack))
+                    {
+                        unfired += amount;
+
+                        // Track max hoursHeatReceived for unfired items
+                        double itemHeatReceived = stack.Attributes?.TryGetFloat("hoursHeatReceived") ?? 0;
+                        if (itemHeatReceived > maxHoursHeatReceived)
+                        {
+                            maxHoursHeatReceived = itemHeatReceived;
+                        }
+                    }
+                    else
+                    {
+                        fired += amount;
+                    }
+                }
+            }
+        }
+
+        return (unfired, fired, maxHoursHeatReceived);
+    }
+
+    private static double GetMinFuelTimeRemaining(IWorldAccessor world, List<BlockPos> itemPositions)
+    {
+        double minTime = double.MaxValue;
+        bool anyBurning = false;
+
+        foreach (var gridPos in itemPositions)
+        {
+            // Fuel is 2 blocks below grating/item position
+            var fuelPos = gridPos.DownCopy(2);
+
+            if (world.BlockAccessor.GetBlockEntity(fuelPos) is BlockEntityCoalPile pile && pile.IsBurning)
+            {
+                anyBurning = true;
+
+                float burnHoursPerLayer = pile.BurnHoursPerLayer;
+                var inv = pile.GetField<InventoryGeneric>("inventory");
+                int stackSize = inv?[0]?.StackSize ?? 0;
+                double totalHours = stackSize / 2.0 * burnHoursPerLayer;
+
+                double burnStart = pile.GetField<double>("burnStartTotalHours");
+                double elapsed = world.Calendar.TotalHours - burnStart;
+                double remaining = totalHours - elapsed;
+
+                if (remaining < minTime)
+                {
+                    minTime = remaining;
+                }
+            }
+        }
+
+        return anyBurning ? Math.Max(0, minTime) : -1;
     }
 
     public static string GetSteelInfo(this string __result, IWorldAccessor world, BlockPos pos)

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -352,7 +352,7 @@ public static class InfoExtensions
             sb.AppendLine()
                 .Append(ColorText(Text.Coke))
                 .Append(": ")
-                .Append(ColorText(Text.Hours(hours)));
+                .Append(ColorText(Text.HoursAndMinutes(hours)));
 
             return sb.ToString().TrimEnd();
         }

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -367,41 +367,76 @@ public static class InfoExtensions
             return __result;
         }
 
-        if (world.BlockAccessor.GetBlock(pos) is not BlockDoor blockDoor) return __result;
-        if (blockDoor.FirstCodePart() != "irondoor") return __result;
+        Block block = world.BlockAccessor.GetBlock(pos);
+        string codePath = block.Code.Path;
+
+        // Check if this is an iron door (regular or metal variant)
+        bool isIronDoor = codePath.Contains("irondoor") ||
+                          (codePath.Contains("door") && codePath.Contains("iron"));
+        if (!isIronDoor) return __result;
 
         StringBuilder sb = new(__result);
 
-        BlockPos _pos = blockDoor.IsUpperHalf() switch
-        {
-            true => pos.DownCopy(),
-            false => pos,
-        };
-
+        // From door, coffin is 2 blocks away in a cardinal direction at same Y level
         BlockPos[] neighborPositions = new BlockPos[]
         {
-            _pos.NorthCopy(3),
-            _pos.EastCopy(3),
-            _pos.SouthCopy(3),
-            _pos.WestCopy(3)
+            pos.NorthCopy(2),
+            pos.EastCopy(2),
+            pos.SouthCopy(2),
+            pos.WestCopy(2)
         };
 
-        foreach (BlockPos blockPos in neighborPositions)
+        foreach (BlockPos coffinPos in neighborPositions)
         {
-            if (world.BlockAccessor.GetBlockEntity(blockPos) is not BlockEntityStoneCoffin be) continue;
+            var coffinBlock = world.BlockAccessor.GetBlock(coffinPos);
 
-            bool processComplete = be.GetField<bool>("processComplete");
-            if (processComplete)
+            // Look for stonecoffin or stonecoffinsection
+            if (!coffinBlock.Code.Path.Contains("stonecoffin")) continue;
+
+            // Get the coffin entity (stonecoffinsection has BlockEntityStoneCoffin)
+            if (world.BlockAccessor.GetBlockEntity(coffinPos) is BlockEntityStoneCoffin be)
             {
-                sb.AppendLine(Lang.Get("Carburization process complete. Break to retrieve blister steel."));
-                continue;
+                bool processComplete = be.GetField<bool>("processComplete");
+                if (processComplete)
+                {
+                    sb.AppendLine(Lang.Get("Carburization process complete. Break to retrieve blister steel."));
+                }
+                else
+                {
+                    double progress = be.GetField<double>("progress");
+                    if (progress > 0.0)
+                    {
+                        int percent = (int)(progress * 100.0);
+                        sb.AppendLine(Text.CarburizationComplete(percent));
+                    }
+                }
             }
 
-            double progress = be.GetField<double>("progress");
-            if (progress <= 0.0) continue;
+            // Fuel is 2 blocks below the coffin
+            BlockPos fuelPos = coffinPos.DownCopy(2);
+            if (world.BlockAccessor.GetBlockEntity(fuelPos) is BlockEntityCoalPile fuelPile)
+            {
+                if (fuelPile.IsBurning)
+                {
+                    // Calculate actual burn time based on fuel type and stack size
+                    float burnHoursPerLayer = fuelPile.BurnHoursPerLayer;
+                    var inventory = fuelPile.GetField<InventoryGeneric>("inventory");
+                    int stackSize = inventory?[0]?.StackSize ?? 0;
+                    double totalBurnHours = stackSize / 2.0 * burnHoursPerLayer;
 
-            int percent = (int)(progress * 100.0);
-            sb.AppendLine(Text.CarburizationComplete(percent));
+                    double burnStart = fuelPile.GetField<double>("burnStartTotalHours");
+                    double hoursElapsed = world.Calendar.TotalHours - burnStart;
+                    double hours = totalBurnHours - hoursElapsed;
+
+                    sb.AppendLine(ColorText(Text.Fuel + ": " + Text.HoursAndMinutes(hours)));
+                }
+                else
+                {
+                    sb.AppendLine(ColorText(Text.Fuel + ": " + Lang.Get("Not burning")));
+                }
+            }
+
+            break; // Found the coffin, no need to check other directions
         }
 
         return sb.ToString().TrimEnd();

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -360,6 +360,60 @@ public static class InfoExtensions
         return __result;
     }
 
+    // Beehive kiln takes approximately 10.9 hours total to fire items.
+    // See: https://wiki.vintagestory.at/Beehive_kiln/draft
+    private const double BeehiveKilnFiringHours = 10.9;
+
+    public static string GetBeehiveKilnInfo(this string __result, IWorldAccessor world, BlockPos pos)
+    {
+        if (Core.Config == null || !Core.Config.ShowBeehiveKilnProgress)
+        {
+            return __result;
+        }
+
+        Block block = world.BlockAccessor.GetBlock(pos);
+        if (block?.Code?.Path == null || !block.Code.Path.Contains("doorkiln")) return __result;
+
+        StringBuilder sb = new(__result);
+
+        // Search nearby for the kiln entity (within 2 blocks in all directions)
+        for (int dx = -2; dx <= 2; dx++)
+        {
+            for (int dy = -2; dy <= 2; dy++)
+            {
+                for (int dz = -2; dz <= 2; dz++)
+                {
+                    var neighborPos = pos.AddCopy(dx, dy, dz);
+                    var be = world.BlockAccessor.GetBlockEntity(neighborPos);
+                    if (be?.GetType().Name != "BlockEntityBeeHiveKiln") continue;
+
+                    bool receivesHeat = be.GetField<bool>("receivesHeat");
+                    if (!receivesHeat) continue;
+
+                    double totalHoursHeatReceived = be.GetField<double>("TotalHoursHeatReceived");
+                    double hoursRemaining = BeehiveKilnFiringHours - totalHoursHeatReceived;
+
+                    if (hoursRemaining > 0)
+                    {
+                        sb.AppendLine();
+                        sb.Append(ColorText(Lang.Get("Kiln")));
+                        sb.Append(": ");
+                        sb.Append(ColorText(Text.HoursAndMinutes(hoursRemaining)));
+                    }
+                    else
+                    {
+                        sb.AppendLine();
+                        sb.Append(ColorText(Lang.Get("Kiln firing complete")));
+                    }
+
+                    return sb.ToString().TrimEnd();
+                }
+            }
+        }
+
+        return __result;
+    }
+
     public static string GetSteelInfo(this string __result, IWorldAccessor world, BlockPos pos)
     {
         if (Core.Config == null || !Core.Config.ShowCementationFurnaceProgress)

--- a/ExtraInfo/src/Utility/InfoExtensions.cs
+++ b/ExtraInfo/src/Utility/InfoExtensions.cs
@@ -393,6 +393,11 @@ public static class InfoExtensions
             // Look for stonecoffin or stonecoffinsection
             if (!coffinBlock.Code.Path.Contains("stonecoffin")) continue;
 
+            // Check fuel status first (2 blocks below the coffin)
+            BlockPos fuelPos = coffinPos.DownCopy(2);
+            var fuelPile = world.BlockAccessor.GetBlockEntity(fuelPos) as BlockEntityCoalPile;
+            bool isBurning = fuelPile?.IsBurning ?? false;
+
             // Get the coffin entity (stonecoffinsection has BlockEntityStoneCoffin)
             if (world.BlockAccessor.GetBlockEntity(coffinPos) is BlockEntityStoneCoffin be)
             {
@@ -409,14 +414,17 @@ public static class InfoExtensions
                         int percent = (int)(progress * 100.0);
                         sb.AppendLine(Text.CarburizationComplete(percent));
                     }
+                    else if (isBurning)
+                    {
+                        sb.AppendLine(Lang.Get("extrainfo:Carburization.Starting"));
+                    }
                 }
             }
 
-            // Fuel is 2 blocks below the coffin
-            BlockPos fuelPos = coffinPos.DownCopy(2);
-            if (world.BlockAccessor.GetBlockEntity(fuelPos) is BlockEntityCoalPile fuelPile)
+            // Display fuel status
+            if (fuelPile != null)
             {
-                if (fuelPile.IsBurning)
+                if (isBurning)
                 {
                     // Calculate actual burn time based on fuel type and stack size
                     float burnHoursPerLayer = fuelPile.BurnHoursPerLayer;


### PR DESCRIPTION
Adds beehive kiln support, displaying remaining firing time, item counts (unfired/fired), and fuel time when looking at the kiln door.  Note that this builds off of #6.


###  Details
  - Displays remaining firing time (based on 10.9 hour total firing duration)
  - Shows unfired/fired item counts from the 3x3 grid
  - Shows fuel burn time remaining from coal piles
  - Handles various kiln states (actively firing, complete, needs fuel, empty)

###  Test plan

  - Place a beehive kiln with unfired items and verify the door shows firing time, item counts, and fuel time
  - Verify kiln display updates as items fire and fuel burns
  - Test config setting ShowBeehiveKilnProgress enables/disables the feature
